### PR TITLE
New features: sqlite storage, export to a different format, csv output, markdown output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "rtoml>=0.12.0",
     "ryaml>=0.4.0",
     "peewee>=3.17.8",
+    "jinja2>=3.1.5",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "click-datetime>=0.4.0",
     "rtoml>=0.12.0",
     "ryaml>=0.4.0",
+    "peewee>=3.17.8",
 ]
 
 [project.scripts]

--- a/src/sigye/cli.py
+++ b/src/sigye/cli.py
@@ -173,3 +173,12 @@ def list_entries(context: ContextObject, time_period, start_date, end_date, tag,
     )
     time_list = context.tts.list_entries(filter=filter)
     context.output.multiple_entries_output(time_list)
+
+
+@cli.command("export")
+@click.argument("export_filename", required=True, type=click.Path(path_type=Path))
+@pass_context_object
+def export(context: ContextObject, export_filename):
+    """export time entries to a file"""
+    records_exported = context.tts.export_entries(export_filename)
+    context.output.export_output(records_exported, export_filename)

--- a/src/sigye/config/settings.py
+++ b/src/sigye/config/settings.py
@@ -23,7 +23,7 @@ class AutoTagRule(BaseModel):
 
 
 class Settings(BaseSettings):
-    data_filename: str = Field(default=str(DEFAULT_DATA_FILENAME))
+    data_filename: Path = Field(default=str(DEFAULT_DATA_FILENAME))
     locale: str = Field(default="en_US")
     auto_tag_rules: list[AutoTagRule] = []
     editor: str = Field(default=DEFAULT_EDITOR)  # really the editor command in the shell

--- a/src/sigye/output/__init__.py
+++ b/src/sigye/output/__init__.py
@@ -1,6 +1,7 @@
 import sys
 
 from .json_output import JsonOutput
+from .markdown_output import MarkdownOutput
 from .output import OutputFormatter, OutputType
 from .output_utils import validate_output_format
 from .rich_text_output import RichTextOutput
@@ -37,4 +38,6 @@ def create_output_formatter(output_format: OutputType | None, force: bool = Fals
             return RichTextOutput()
         case OutputType.YAML:
             return YamlOutput()
+        case OutputType.MARKDOWN:
+            return MarkdownOutput()
     raise ValueError(f"Unsupported output format: {output_format}")

--- a/src/sigye/output/__init__.py
+++ b/src/sigye/output/__init__.py
@@ -1,5 +1,6 @@
 import sys
 
+from .csv_output import CsvOutput
 from .json_output import JsonOutput
 from .markdown_output import MarkdownOutput
 from .output import OutputFormatter, OutputType
@@ -9,6 +10,7 @@ from .text_output import RawTextOutput
 from .yaml_output import YamlOutput
 
 __all__ = [
+    CsvOutput,
     JsonOutput,
     OutputFormatter,
     OutputType,
@@ -40,4 +42,6 @@ def create_output_formatter(output_format: OutputType | None, force: bool = Fals
             return YamlOutput()
         case OutputType.MARKDOWN:
             return MarkdownOutput()
+        case OutputType.CSV:
+            return CsvOutput()
     raise ValueError(f"Unsupported output format: {output_format}")

--- a/src/sigye/output/csv_output.py
+++ b/src/sigye/output/csv_output.py
@@ -1,0 +1,43 @@
+import csv
+import sys
+from typing import Any
+
+from ..models import TimeEntry
+from .output import OutputFormatter
+
+
+class CsvOutput(OutputFormatter):
+    def _get_header(self):
+        return [
+            "id",
+            "start_time",
+            "end_time",
+            "project",
+            "comment",
+            "tags",
+        ]
+
+    def _get_row(self, entry: TimeEntry):
+        return [
+            entry.id,
+            entry.naive_start_time.strftime("%Y-%m-%d %H:%M:%S"),
+            entry.naive_end_time.strftime("%Y-%m-%d %H:%M:%S") if entry.naive_end_time else "",
+            entry.project,
+            entry.comment,
+            "|".join(entry.tags),
+        ]
+
+    def _send_output(self, output: list[list[Any]]) -> None:
+        writer = csv.writer(sys.stdout)
+        writer.writerows(output)
+
+    def single_entry_output(self, entry: TimeEntry | None) -> None:
+        if entry is None:
+            return
+        self._send_output([self._get_header(), self._get_row(entry)])
+
+    def multiple_entries_output(self, entries: list[TimeEntry]) -> None:
+        self._send_output([self._get_header()] + [self._get_row(entry) for entry in entries])
+
+    def export_output(self, count: int, filename: str) -> None:
+        self._send_output([["exported", "filename"], [count, filename]])

--- a/src/sigye/output/json_output.py
+++ b/src/sigye/output/json_output.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from ..models import TimeEntry
 from .output import OutputFormatter
@@ -12,3 +13,6 @@ class JsonOutput(OutputFormatter):
 
     def multiple_entries_output(self, entries: list[TimeEntry]) -> None:
         print(json.dumps([entry.model_dump(mode="json") for entry in entries]))
+
+    def export_output(self, count: int, filename: Path | str) -> None:
+        print(json.dumps({"count": count, "filename": str(filename)}))

--- a/src/sigye/output/markdown_output.py
+++ b/src/sigye/output/markdown_output.py
@@ -1,0 +1,84 @@
+from datetime import timedelta
+from pathlib import Path
+
+from jinja2 import Template
+from pydantic import BaseModel
+
+from ..models import TimeEntry
+from ..utils.datetime_utils import format_delta
+from .output import OutputFormatter
+
+SINGLE_ENTRY = Template(
+    """
+# Time Entry
+
+| field | value |
+|-------|-------|
+| ID | {{ entry.id }} |
+| Start Time | {{ entry.naive_start_time.strftime("%Y-%m-%d %H:%M:%S") }} |
+| Stop Time | {{ entry.naive_end_time.strftime("%Y-%m-%d %H:%M:%S") }} |
+| Delta | {{ entry.humanized_duration }} |
+| Project | {{ entry.project }} |
+| Comment | {{ entry.comment }} |
+| Tags | {{ entry.tags }} |
+"""
+)
+
+
+MULTIPLE_ENTRIES = Template(
+    """
+# Time Entries
+
+| ID | Start Time| Stop Time| Delta |Project |Comment |Tags |
+|----|----------:|---------:|------:|--------|--------|-----|
+{% for entry in entries %}{% if 'total_duration' in entry.model_fields_set %}| | {{ entry.total_description }}| | {{ entry.total_duration }} | | | |{% else %}| {{ entry.id[0:4] }} | {{ entry.naive_start_time.strftime("%Y-%m-%d %H:%M:%S") }}| {{ entry.naive_end_time.strftime("%H:%M:%S") }} | {{ entry.humanized_duration }}| {{ entry.project }} | {{ entry.comment }} | {{ ", ".join(entry.tags) }} |{% endif %}
+{% endfor %}
+"""  # noqa: E501
+)
+
+
+EXPORT_OUTPUT = Template(
+    """
+Exported {{ count }} entries to {{ filename }}
+"""
+)
+
+
+class OutputModel(BaseModel):
+    total_description: str = ""
+    total_duration: str = ""
+
+
+class MarkdownOutput(OutputFormatter):
+    def single_entry_output(self, entry: TimeEntry | None) -> None:
+        if entry is None:
+            print("No active time record.")
+        else:
+            print(SINGLE_ENTRY.render(entry=entry))
+
+    def multiple_entries_output(self, entries: list[TimeEntry]) -> None:
+        output_entries = []
+        if len(entries):
+            current_date = entries[0].naive_start_time.date()
+            subtotal_delta = timedelta(0)
+            total_delta = timedelta(0)
+            for entry in entries:
+                total_delta += (entry.naive_end_time - entry.naive_start_time) if entry.naive_end_time else timedelta(0)
+                if entry.naive_start_time.date() != current_date:
+                    output_entries.append(
+                        OutputModel(total_description="*subtotal*", total_duration=format_delta(subtotal_delta))
+                    )
+                    current_date = entry.naive_start_time.date()
+                    subtotal_delta = timedelta(0)
+                subtotal_delta += (
+                    (entry.naive_end_time - entry.naive_start_time) if entry.naive_end_time else timedelta(0)
+                )
+                output_entries.append(entry)
+            output_entries.append(
+                OutputModel(total_description="*subtotal*", total_duration=format_delta(subtotal_delta))
+            )
+            output_entries.append(OutputModel(total_description="**total**", total_duration=format_delta(total_delta)))
+        print(MULTIPLE_ENTRIES.render(entries=output_entries))
+
+    def export_output(self, count: int, filename: Path | str) -> None:
+        print(EXPORT_OUTPUT.render(count=count, filename=filename))

--- a/src/sigye/output/output.py
+++ b/src/sigye/output/output.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from pathlib import Path
 
 from ..models import TimeEntry
 
@@ -8,6 +9,7 @@ class OutputType(StrEnum):
     JSON = "json"
     RICH = "rich"
     YAML = "yaml"
+    MARKDOWN = "markdown"
     EMPTY = ""
 
     @classmethod
@@ -25,4 +27,7 @@ class OutputFormatter:
         raise NotImplementedError("output method is not implemented")
 
     def multiple_entries_output(self, entries: list[TimeEntry]) -> None:
+        raise NotImplementedError("output method is not implemented")
+
+    def export_output(self, count: int, filename: Path | str) -> None:
         raise NotImplementedError("output method is not implemented")

--- a/src/sigye/output/output.py
+++ b/src/sigye/output/output.py
@@ -10,6 +10,7 @@ class OutputType(StrEnum):
     RICH = "rich"
     YAML = "yaml"
     MARKDOWN = "markdown"
+    CSV = "csv"
     EMPTY = ""
 
     @classmethod

--- a/src/sigye/output/rich_text_output.py
+++ b/src/sigye/output/rich_text_output.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+from pathlib import Path
 
 from rich.console import Console
 from rich.table import Table
@@ -80,5 +81,13 @@ class RichTextOutput(OutputFormatter):
         _check_and_print_total(table, subtotal_delta, _("subtotal"), "#a0a0a0")
         table.add_section()
         _check_and_print_total(table, total_delta, _("total"), "yellow")
+        console = Console()
+        console.print(table)
+
+    def export_output(self, count: int, filename: Path | str) -> None:
+        table = Table(title=_("Export"))
+        table.add_column(_("records exported"))
+        table.add_column(_("filename"))
+        table.add_row(str(count), str(filename))
         console = Console()
         console.print(table)

--- a/src/sigye/output/tests/test_csv_output.py
+++ b/src/sigye/output/tests/test_csv_output.py
@@ -1,0 +1,48 @@
+from ...models import TimeEntry
+from .. import CsvOutput
+
+
+def test_csv_output_single_entry():
+    entry = TimeEntry(
+        id="1234567890",
+        start_time="2021-01-01T00:00:00",
+        end_time="2021-01-01T01:00:00",
+        project="test",
+        comment="test",
+        tags=["test"],
+    )
+    output = CsvOutput()
+    output.single_entry_output(entry)
+
+
+def test_csv_output_multiple_entries():
+    entries = [
+        TimeEntry(
+            id="1234567890",
+            start_time="2021-01-01T00:00:00",
+            end_time="2021-01-01T01:00:00",
+            project="test",
+            comment="test",
+            tags=["test"],
+        ),
+        TimeEntry(
+            id="1234567890",
+            start_time="2021-01-01T00:00:00",
+            end_time="2021-01-01T01:00:00",
+            project="test",
+            comment="test",
+            tags=["test"],
+        ),
+    ]
+    output = CsvOutput()
+    output.multiple_entries_output(entries)
+
+
+def test_csv_output_export():
+    output = CsvOutput()
+    output.export_output(2, "test.csv")
+
+
+def test_csv_output_no_entry():
+    output = CsvOutput()
+    output.single_entry_output(None)

--- a/src/sigye/output/tests/test_markdown_output.py
+++ b/src/sigye/output/tests/test_markdown_output.py
@@ -1,0 +1,53 @@
+from ...models import TimeEntry
+from ..markdown_output import MarkdownOutput
+
+
+def test_markdown_entry():
+    entry = TimeEntry(
+        id="1234567890",
+        start_time="2021-01-01T00:00:00",
+        end_time="2021-01-01T01:00:00",
+        project="test",
+        comment="test",
+        tags=["test"],
+    )
+    output = MarkdownOutput()
+    output.single_entry_output(entry)
+
+    # TODO: Check the output
+
+
+def test_markdown_multiple_entries():
+    entries = [
+        TimeEntry(
+            id="1234567890",
+            start_time="2021-01-01T00:00:00",
+            end_time="2021-01-01T01:00:00",
+            project="test",
+            comment="test",
+            tags=["test"],
+        ),
+        TimeEntry(
+            id="1234567890",
+            start_time="2021-01-01T00:00:00",
+            end_time="2021-01-01T01:00:00",
+            project="test",
+            comment="test",
+            tags=["test"],
+        ),
+    ]
+    output = MarkdownOutput()
+    output.multiple_entries_output(entries)
+    # TODO: Check the output
+
+
+def test_markdown_export():
+    output = MarkdownOutput()
+    output.export_output(2, "test.md")
+    # TODO: Check the output
+
+
+def test_markdown_no_entry():
+    output = MarkdownOutput()
+    output.single_entry_output(None)
+    # TODO: Check the output

--- a/src/sigye/output/text_output.py
+++ b/src/sigye/output/text_output.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ..models import TimeEntry
 from .output import OutputFormatter
 
@@ -15,3 +17,6 @@ class RawTextOutput(OutputFormatter):
     def multiple_entries_output(self, entries: list[TimeEntry]) -> None:
         for entry in entries:
             print(self._entry_to_str(entry))
+
+    def export_output(self, count: int, filename: Path | str) -> None:
+        return print(f"Exported {count} entries to {filename}")

--- a/src/sigye/output/yaml_output.py
+++ b/src/sigye/output/yaml_output.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import ryaml
 
 from ..models import TimeEntry
@@ -12,3 +14,6 @@ class YamlOutput(OutputFormatter):
 
     def multiple_entries_output(self, entries: list[TimeEntry]) -> None:
         print(ryaml.dumps({"entries": [entry.model_dump(mode="json") for entry in entries]}))
+
+    def export_output(self, count: int, filename: Path | str) -> None:
+        print("")

--- a/src/sigye/repositories/__init__.py
+++ b/src/sigye/repositories/__init__.py
@@ -1,4 +1,5 @@
 from .time_entry_repo import TimeEntryRepository
 from .time_entry_repo_file import TimeEntryRepositoryFile
+from .time_entry_repo_orm import TimeEntryRepositoryORM
 
-__all__ = ["TimeEntryRepository", "TimeEntryRepositoryFile"]
+__all__ = ["TimeEntryRepository", "TimeEntryRepositoryFile", "TimeEntryRepositoryORM"]

--- a/src/sigye/repositories/tests/test_repo_file.py
+++ b/src/sigye/repositories/tests/test_repo_file.py
@@ -5,7 +5,8 @@ import pytest
 import rtoml as toml
 import ryaml
 
-from ..time_entry_repo_file import FormatFactory, JSONFormat, TOMLFormat, YAMLFormat
+from ...models import TimeEntry
+from ..time_entry_repo_file import FormatFactory, JSONFormat, TimeEntryRepositoryFile, TOMLFormat, YAMLFormat
 
 
 def test_file_format_factory():
@@ -46,3 +47,41 @@ def test_json_format():
         fmt.save_data(data, f)
         f.seek(0)
         assert json.dumps(data) == f.read()
+
+
+def test_supported_formats():
+    assert FormatFactory.get_supported_formats() == ["yaml", "yml", "toml", "json"]
+
+
+def test_time_entry_repo_file(tmp_path):
+    for fmt in ["yaml", "toml", "json"]:
+        filename = tmp_path / f"test.{fmt}"
+        repo = TimeEntryRepositoryFile(filename)
+        assert repo._format.suffix == f".{fmt}"
+
+        assert repo.get_all() == []
+        with pytest.raises(KeyError):
+            repo.get_entry_by_id("1")
+
+        entry = TimeEntry(
+            project="test", start_time="2021-01-01T00:00:00", end_time="2021-01-01T01:00:00", comment="test comment"
+        )
+        repo.save(entry)
+
+        assert repo.get_entry_by_id(entry.id) == entry
+
+        entry2 = TimeEntry(project="test2", start_time="2021-01-02T00:00:00", comment="test comment 2")
+
+        repo.save(entry2)
+        assert repo.get_entry_by_id(entry2.id) == entry2
+
+        repo.delete_entry(entry2.id)
+        with pytest.raises(KeyError):
+            repo.get_entry_by_id(entry2.id)
+
+        with pytest.raises(KeyError):
+            repo.delete_entry(entry2.id)
+
+        assert repo.filter(filter=None) == [entry]
+
+        assert repo.get_by_project("test") == [entry]

--- a/src/sigye/repositories/tests/test_repo_orm.py
+++ b/src/sigye/repositories/tests/test_repo_orm.py
@@ -1,0 +1,73 @@
+import pytest
+
+from ...models import EntryListFilter, TimeEntry
+from ..time_entry_repo_orm import TimeEntryRepositoryORM
+
+
+def test_entry_repo_orm_empty():
+    """Test ORM repo with no entries."""
+    repo = TimeEntryRepositoryORM(":memory:")
+
+    assert repo.get_all() == []
+    assert repo.get_by_project("test") == []
+    with pytest.raises(KeyError):
+        repo.get_entry_by_id("test")
+    assert repo.filter() == []
+
+
+def test_entry_repo_orm_standard():
+    repo = TimeEntryRepositoryORM(":memory:")
+    entry = TimeEntry(project="test", start_time="2021-01-01T00:00:00", tags=["tag1", "tag2"])
+    repo.save(entry)
+    assert repo.get_active_entry() == entry
+
+
+def test_entry_repo_orm_filter():
+    repo = TimeEntryRepositoryORM(":memory:")
+    entry1 = TimeEntry(
+        project="test",
+        start_time="2021-01-01T00:00:00",
+        end_time="2021-01-01T01:00:00",
+        tags=["tag1", "tag2"],
+        comment="test",
+    )
+    entry2 = TimeEntry(
+        project="test2", start_time="2021-01-02T00:00:00", end_time="2021-01-02T01:30:00", tags=["tag2", "tag3"]
+    )
+    entry3 = TimeEntry(
+        project="test3", start_time="2021-01-03T00:00:00", end_time="2021-01-03T02:00:00", tags=["tag1", "tag3"]
+    )
+    repo.save(entry1)
+    repo.save(entry2)
+    repo.save(entry3)
+    filter1 = EntryListFilter(projects=["test"])
+    assert repo.filter(filter=filter1) == [entry1]
+    filter2 = EntryListFilter(tags=["tag1"])
+    assert repo.filter(filter=filter2) == [entry1, entry3]
+    filter3 = EntryListFilter(start_date="2021-01-02")
+    assert repo.filter(filter=filter3) == [entry2, entry3]
+    assert repo.filter() == [entry1, entry2, entry3]
+    filter4 = EntryListFilter(end_date="2021-01-02")
+    assert repo.filter(filter=filter4) == [entry1, entry2]
+    filter5 = EntryListFilter(id=entry1.id[0:4])
+    assert repo.filter(filter=filter5) == [entry1]
+    filter6 = EntryListFilter(tags=["blah"])
+    assert repo.filter(filter=filter6) == []
+
+
+def test_entry_repo_orm_delete():
+    repo = TimeEntryRepositoryORM(":memory:")
+    entry1 = TimeEntry(
+        project="test",
+        start_time="2021-01-01T00:00:00",
+        stop_time="2021-01-01T01:00:00",
+        tags=["tag1", "tag2"],
+        comment="test",
+    )
+    repo.save(entry1)
+    assert repo.get_all() == [entry1]
+    d_entry = repo.delete_entry(entry1.id)
+    assert d_entry == entry1
+    assert repo.get_all() == []
+    with pytest.raises(KeyError):
+        repo.delete_entry("test")

--- a/src/sigye/repositories/tests/test_repo_orm.py
+++ b/src/sigye/repositories/tests/test_repo_orm.py
@@ -71,3 +71,23 @@ def test_entry_repo_orm_delete():
     assert repo.get_all() == []
     with pytest.raises(KeyError):
         repo.delete_entry("test")
+
+
+def test_entry_repo_orm_save_all():
+    repo = TimeEntryRepositoryORM(":memory:")
+    entry1 = TimeEntry(
+        project="test",
+        start_time="2021-01-01T00:00:00",
+        stop_time="2021-01-01T01:00:00",
+        tags=["tag1", "tag2"],
+        comment="test",
+    )
+    entry2 = TimeEntry(
+        project="test2",
+        start_time="2021-01-02T00:00:00",
+        stop_time="2021-01-02T01:00:00",
+        tags=["tag2", "tag3"],
+        comment="test2",
+    )
+    repo.save_all([entry1, entry2])
+    assert repo.get_all() == [entry1, entry2]

--- a/src/sigye/repositories/time_entry_repo.py
+++ b/src/sigye/repositories/time_entry_repo.py
@@ -5,7 +5,7 @@ from ..models import EntryListFilter, TimeEntry
 
 class TimeEntryRepository(ABC):
     @abstractmethod
-    def save(self, entry: TimeEntry) -> TimeEntry:
+    def save(self, entry: TimeEntry) -> None:
         pass
 
     @abstractmethod
@@ -21,7 +21,7 @@ class TimeEntryRepository(ABC):
         pass
 
     @abstractmethod
-    def filter(self, *, filter: EntryListFilter):
+    def filter(self, *, filter: EntryListFilter) -> list[TimeEntry]:
         pass
 
     @abstractmethod
@@ -30,4 +30,8 @@ class TimeEntryRepository(ABC):
 
     @abstractmethod
     def delete_entry(self, id: str) -> TimeEntry:
+        pass
+
+    @abstractmethod
+    def save_all(self, entries: list[TimeEntry]) -> None:
         pass

--- a/src/sigye/repositories/time_entry_repo_file.py
+++ b/src/sigye/repositories/time_entry_repo_file.py
@@ -163,7 +163,7 @@ class TimeEntryRepositoryFile(TimeEntryRepository):
             (not filter.projects or self._project_matching(filter.projects, entry.project)),
             # Date filters
             (not filter.start_date or entry.start_time.date() >= filter.start_date),
-            (not filter.end_date or (entry.end_time and entry.end_time.date() <= filter.end_date)),
+            (not filter.end_date or (entry.start_time.date() <= filter.end_date)),
             # Tag filter
             (not filter.tags or any(tag in entry.tags for tag in filter.tags)),
         ]

--- a/src/sigye/repositories/time_entry_repo_file.py
+++ b/src/sigye/repositories/time_entry_repo_file.py
@@ -193,3 +193,8 @@ class TimeEntryRepositoryFile(TimeEntryRepository):
         entries.sort(key=lambda x: x["start_time"])
         data["entries"] = entries
         self._save_data(data)
+
+    def save_all(self, entries: list[TimeEntry]) -> None:
+        data = self._load_data()
+        data["entries"] = [entry.model_dump(mode="json") for entry in entries]
+        self._save_data(data)

--- a/src/sigye/repositories/time_entry_repo_orm.py
+++ b/src/sigye/repositories/time_entry_repo_orm.py
@@ -101,3 +101,8 @@ class TimeEntryRepositoryORM(TimeEntryRepository):
         except TimeEntryORM.DoesNotExist:
             orm_entry = TimeEntryORM.create_from_model(entry)
         orm_entry.save()
+
+    def save_all(self, entries: list[TimeEntry]) -> None:
+        with db.atomic():
+            data = [entry.model_dump(mode="json") for entry in entries]
+            TimeEntryORM.insert_many(data).execute()

--- a/src/sigye/repositories/time_entry_repo_orm.py
+++ b/src/sigye/repositories/time_entry_repo_orm.py
@@ -1,0 +1,103 @@
+import json
+from datetime import datetime
+from typing import Self
+
+from peewee import CharField, DateTimeField, Model, fn
+from playhouse.sqlite_ext import JSONField, SqliteExtDatabase
+
+from ..models import EntryListFilter, TimeEntry
+from .time_entry_repo import TimeEntryRepository
+
+db = SqliteExtDatabase(None)
+
+
+class TimeEntryORM(Model):
+    id = CharField(primary_key=True)
+    start_time = DateTimeField()
+    end_time = DateTimeField(null=True)
+    project = CharField()
+    comment = CharField()
+    tags = JSONField()
+
+    class Meta:
+        database = db
+        table_name = "time_entries"
+
+    def to_model(self) -> TimeEntry:
+        return TimeEntry(
+            id=self.id,
+            start_time=self.start_time,
+            end_time=self.end_time,
+            project=self.project,
+            comment=self.comment,
+            tags=set(self.tags),
+        )
+
+    @classmethod
+    def create_from_model(cls, entry: TimeEntry) -> Self:
+        return cls.create(
+            id=entry.id,
+            start_time=entry.start_time,
+            end_time=entry.end_time,
+            project=entry.project,
+            comment=entry.comment,
+            tags=list(entry.tags),
+        )
+
+
+def json_array_contains(json_array, value):
+    return value in json.loads(json_array) if json_array else False
+
+
+class TimeEntryRepositoryORM(TimeEntryRepository):
+    def __init__(self, db_path: str):
+        db.init(db_path)
+        db.connect()
+        db.create_tables([TimeEntryORM])
+        db.connection().create_function("json_array_contains", 2, json_array_contains)
+
+    def get_all(self) -> list[TimeEntry]:
+        return [entry.to_model() for entry in TimeEntryORM.select().order_by(TimeEntryORM.start_time.asc())]
+
+    def get_by_project(self, project: str) -> list[TimeEntry]:
+        return [entry.to_model() for entry in TimeEntryORM.select().where(TimeEntryORM.project == project)]
+
+    def get_entry_by_id(self, id: str) -> TimeEntry:
+        try:
+            return TimeEntryORM.get(TimeEntryORM.id == id).to_model()
+        except TimeEntryORM.DoesNotExist as e:
+            raise KeyError("record id not found") from e
+
+    def delete_entry(self, id: str) -> TimeEntry:
+        try:
+            entry = TimeEntryORM.get(TimeEntryORM.id == id)
+            entry.delete_instance()
+            return entry.to_model()
+        except TimeEntryORM.DoesNotExist as e:
+            raise KeyError("record id not found") from e
+
+    def get_active_entry(self):
+        return TimeEntryORM.get(TimeEntryORM.end_time.is_null()).to_model()
+
+    def filter(self, *, filter: EntryListFilter | None = None) -> list[TimeEntry]:
+        query = TimeEntryORM.select().order_by(TimeEntryORM.start_time.asc())
+        if filter:
+            if filter.id:
+                query = query.where(TimeEntryORM.id.startswith(filter.id))
+            if filter.projects:
+                query = query.where(TimeEntryORM.project.in_(filter.projects))
+            if filter.start_date:
+                query = query.where(TimeEntryORM.start_time >= filter.start_date)
+            if filter.end_date:
+                query = query.where(TimeEntryORM.start_time <= datetime.combine(filter.end_date, datetime.max.time()))
+            if filter.tags:
+                for tag in filter.tags:
+                    query = query.where(fn.json_array_contains(TimeEntryORM.tags, tag))
+        return [entry.to_model() for entry in query]
+
+    def save(self, entry: TimeEntry) -> None:
+        try:
+            orm_entry = TimeEntryORM.get(TimeEntryORM.id == entry.id)
+        except TimeEntryORM.DoesNotExist:
+            orm_entry = TimeEntryORM.create_from_model(entry)
+        orm_entry.save()

--- a/src/sigye/services.py
+++ b/src/sigye/services.py
@@ -95,3 +95,12 @@ class TimeTrackingService:
         elif len(entries) > 1:
             raise IndexError("Multiple entries found")
         raise KeyError("record id not found")
+
+    def export_entries(self, filename: str) -> int:
+        """Export entries to a file"""
+        entries = self.list_entries()
+        output_repository = (
+            TimeEntryRepositoryFile(filename) if filename.suffix != ".db" else TimeEntryRepositoryORM(filename)
+        )
+        output_repository.save_all(entries)
+        return len(entries)

--- a/src/sigye/services.py
+++ b/src/sigye/services.py
@@ -4,7 +4,7 @@ from .config.settings import Settings
 from .editors import Editor
 from .editors.shell_editor import ShellEditor
 from .models import EntryListFilter, TimeEntry
-from .repositories import TimeEntryRepository, TimeEntryRepositoryFile
+from .repositories import TimeEntryRepository, TimeEntryRepositoryFile, TimeEntryRepositoryORM
 
 
 class TimeTrackingService:
@@ -15,7 +15,11 @@ class TimeTrackingService:
         editor: Editor | None = None,
     ):
         self.settings = settings
-        self.repository = repository or TimeEntryRepositoryFile(settings.data_filename)
+        self.repository = repository or (
+            TimeEntryRepositoryORM(settings.data_filename)
+            if settings.data_filename.suffix == ".db"
+            else TimeEntryRepositoryFile(settings.data_filename)
+        )
         self.editor = editor or ShellEditor(settings.editor, settings.editor_format)
 
     def start_tracking(

--- a/src/sigye/tests/test_cli.py
+++ b/src/sigye/tests/test_cli.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import mock
 
 from click.testing import CliRunner
@@ -25,7 +26,7 @@ def test_load_settings(tmp_path):
     config_file.write_text(config_content)
     settings = load_settings(config_file)
     assert settings.locale == "en_US"
-    assert settings.data_filename == "test.yaml"
+    assert settings.data_filename == Path("test.yaml")
 
 
 def test_start_command(tmp_path):

--- a/src/sigye/utils/extra/generator.py
+++ b/src/sigye/utils/extra/generator.py
@@ -2,7 +2,7 @@ import random
 from datetime import datetime, timedelta
 
 from ...models import TimeEntry
-from ...repositories import TimeEntryRepositoryFile
+from ...repositories import TimeEntryRepositoryFile, TimeEntryRepositoryORM
 
 
 def generate_fake_entries(count: int) -> list[TimeEntry]:
@@ -27,11 +27,11 @@ def generate_fake_entries(count: int) -> list[TimeEntry]:
 def save_fake_entries(filename: str, count: int):
     """Generate and save fake time entries to a file"""
     entries = generate_fake_entries(count)
-    repo = TimeEntryRepositoryFile(filename)
+    repo = TimeEntryRepositoryORM(filename) if filename.endswith(".db") else TimeEntryRepositoryFile(filename)
     for entry in entries:
         repo.save(entry)
     return entries
 
 
 if __name__ == "__main__":
-    save_fake_entries("fake_entries.yaml", 1000)
+    save_fake_entries("fake_entries.db", 1000)

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -138,6 +150,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348 },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149 },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118 },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993 },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178 },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319 },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352 },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097 },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601 },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352 },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122 },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085 },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978 },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208 },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357 },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344 },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101 },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603 },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510 },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486 },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480 },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914 },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796 },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473 },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114 },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
 ]
 
 [[package]]
@@ -385,6 +435,7 @@ dependencies = [
     { name = "click-aliases" },
     { name = "click-datetime" },
     { name = "humanize" },
+    { name = "jinja2" },
     { name = "peewee" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -407,6 +458,7 @@ requires-dist = [
     { name = "click-aliases", specifier = ">=1.0.5" },
     { name = "click-datetime", specifier = ">=0.4.0" },
     { name = "humanize", specifier = ">=4.11.0" },
+    { name = "jinja2", specifier = ">=3.1.5" },
     { name = "peewee", specifier = ">=3.17.8" },
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "pydantic-settings", specifier = ">=2.6.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,12 @@ wheels = [
 ]
 
 [[package]]
+name = "peewee"
+version = "3.17.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/dc/832bcf4ea5ee2ebc4ea42ef36e44a451de5d80f8b9858bf2066e30738c67/peewee-3.17.8.tar.gz", hash = "sha256:ce1d05db3438830b989a1b9d0d0aa4e7f6134d5f6fd57686eeaa26a3e6485a8c", size = 948249 }
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -372,13 +378,14 @@ wheels = [
 
 [[package]]
 name = "sigye"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "click-aliases" },
     { name = "click-datetime" },
     { name = "humanize" },
+    { name = "peewee" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rich" },
@@ -400,6 +407,7 @@ requires-dist = [
     { name = "click-aliases", specifier = ">=1.0.5" },
     { name = "click-datetime", specifier = ">=0.4.0" },
     { name = "humanize", specifier = ">=4.11.0" },
+    { name = "peewee", specifier = ">=3.17.8" },
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "pydantic-settings", specifier = ">=2.6.1" },
     { name = "rich", specifier = ">=13.9.4" },


### PR DESCRIPTION
* store in sqlite database (filename ending in `.db`) (closes #11)
* new `export` command to export to any supported storage format: yaml, toml, json, sqlitedb
* command output formats added:
  * markdown... fairly basic markdown template that outputs a markdown table roughly matching the `rich` text output. (closes #10)
  * csv... super basic csv output enough for the spreadsheet warriors
* a little bit more test coverage on storage engines
* fix to start and end date filtering in both sqlite and text file backends
