### PR TITLE
Restrict CI workflow GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+permissions:
+  contents: read
 jobs:
   uv-example:
     name: python


### PR DESCRIPTION
## Summary
- Adds an explicit top-level `permissions: contents: read` block to `.github/workflows/ci.yml`.
- Resolves the open CodeQL code-scanning alert `actions/missing-workflow-permissions` (medium severity, CWE-275).
- The workflow only checks out code and runs tests, so read-only access to repo contents is the least privilege required.

## Test plan
- [x] CI workflow runs successfully on this PR (checkout, uv install, pytest).
- [x] CodeQL re-runs and the existing alert auto-closes after merge.