### PR TITLE
Migrate CLI from click to cappa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ wheels/
 
 # Claude Code
 .claude/
+
+# Added by code-review-graph
+.code-review-graph/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,4 @@ select = [
 extend-fixable = ["E", "F", "UP", "B", "SIM", "I"]
 
 [tool.uv.sources]
-cappa = { git = "https://github.com/swilcox/cappa.git", rev = "feat/aliased-subcommands" }
+cappa = { git = "https://github.com/DanCardin/cappa.git", branch = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,11 @@ license = { text = "MIT License" }
 authors = [{ name = "swilcox", email = "steven@wilcox.be" }]
 requires-python = ">=3.12"
 dependencies = [
-    "click>=8.1.7",
+    "cappa>=0.28",
     "humanize>=4.11.0",
     "pydantic-settings>=2.6.1",
     "pydantic>=2.9.2",
     "rich>=13.9.4",
-    "click-aliases>=1.0.5",
     "rtoml>=0.13.0",
     "ryaml>=0.4.0",
     "peewee>=3.17.8",
@@ -53,3 +52,6 @@ select = [
     "I",
 ]
 extend-fixable = ["E", "F", "UP", "B", "SIM", "I"]
+
+[tool.uv.sources]
+cappa = { git = "https://github.com/swilcox/cappa.git", rev = "feat/aliased-subcommands" }

--- a/src/sigye/cli.py
+++ b/src/sigye/cli.py
@@ -1,13 +1,15 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import date, datetime
 from pathlib import Path
+from typing import Annotated
 
-import click
-from click_aliases import ClickAliasedGroup
+import cappa
 
 from .config.settings import DEFAULT_CONFIG_PATH, Settings
 from .editors import EditorError
 from .models import EntryListFilter
-from .output import OutputFormatter, OutputType, create_output_formatter, validate_output_format
+from .output import OutputFormatter, OutputType, create_output_formatter
+from .output.output_utils import validate_output_format
 from .services import TimeTrackingService
 from .utils.datetime_utils import validate_time
 from .utils.translation import set_locale
@@ -20,171 +22,200 @@ def load_settings(config_file: Path | None = None) -> Settings:
     return settings
 
 
+def _parse_date(value: str) -> date:
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
 @dataclass
 class ContextObject:
     tts: TimeTrackingService
     output: OutputFormatter
 
 
-pass_context_object = click.make_pass_decorator(ContextObject, ensure=True)
-
-
-@click.group(cls=ClickAliasedGroup)
-@click.version_option()
-@click.option(
-    "--config-file",
-    "-c",
-    type=click.Path(path_type=Path),
-    default=DEFAULT_CONFIG_PATH,
-    help="Path to config file",
-    show_default=True,
-)
-@click.option(
-    "--filename",
-    "-f",
-    type=click.Path(path_type=Path),
-    help="Path to data file",
-)
-@click.option(
-    "--output_format",
-    "-o",
-    type=click.Choice(OutputType.choices(), case_sensitive=False),
-    help="Output format",
-    callback=validate_output_format,
-)
-@click.pass_context
-def cli(ctx, config_file, filename, output_format: OutputType | None):
-    settings = load_settings(config_file)
-    settings.data_filename = filename or settings.data_filename
-    settings.output_format = output_format or settings.output_format
-    ctx.obj = ContextObject(
+def build_context(sigye: "Sigye") -> ContextObject:
+    settings = load_settings(sigye.config_file)
+    settings.data_filename = sigye.filename or settings.data_filename
+    settings.output_format = sigye.output_format or settings.output_format
+    return ContextObject(
         TimeTrackingService(settings),
-        create_output_formatter(settings.output_format, force=(bool(output_format))),
+        create_output_formatter(settings.output_format, force=bool(sigye.output_format)),
     )
 
 
-@cli.command("start")
-@click.argument("project", required=True, type=str)
-@click.argument("comment", required=False, type=str, default="")
-@click.option("--tag", required=False, type=str, multiple=True)
-@click.option(
-    "--start_time",
-    "-s",
-    required=False,
-    type=str,
-    help="Start time expressed as HH:MM or HH:MM:SS in 24-hour format or AM/PM",
-    default=None,
-    callback=validate_time,
-)
-@pass_context_object
-def start(context: ContextObject, project, comment, tag, start_time):
-    """start tracking work on a project"""
-    time_entry = context.tts.start_tracking(project, comment=comment, tags=set(tag), start_time=start_time)
-    context.output.single_entry_output(time_entry)
+Context = Annotated[ContextObject, cappa.Dep(build_context)]
 
 
-@cli.command("stop")
-@click.argument("comment", required=False, type=str, default="")
-@click.option(
-    "--stop_time",
-    "-s",
-    callback=validate_time,
-    required=False,
-    type=str,
-    default=None,
-    help="Stop/End time expressed as HH:MM or HH:MM:SS in 24-hour format or AM/PM",
-)
-@pass_context_object
-def stop(context: ContextObject, comment, stop_time):
-    """stop tracking work on a project"""
-    try:
-        if comment:
-            time_entry = context.tts.get_active_entry()
-            time_entry.comment = comment
-            time_entry = context.tts.update_entry(time_entry)
-        time_entry = context.tts.stop_tracking(stop_time=stop_time)
-    except ValueError as e:
-        raise click.ClickException(e) from e
-    context.output.single_entry_output(time_entry)
+@cappa.command(name="start", help="start tracking work on a project")
+@dataclass
+class Start:
+    project: str
+    comment: str = ""
+    tag: Annotated[list[str], cappa.Arg(long=True)] = field(default_factory=list)
+    start_time: Annotated[
+        datetime | None,
+        cappa.Arg(
+            short="-s",
+            long="--start_time",
+            parse=validate_time,
+            parse_inference=False,
+            help="Start time expressed as HH:MM or HH:MM:SS in 24-hour format or AM/PM",
+        ),
+    ] = None
+
+    def __call__(self, context: Context) -> None:
+        time_entry = context.tts.start_tracking(
+            self.project, comment=self.comment, tags=set(self.tag), start_time=self.start_time
+        )
+        context.output.single_entry_output(time_entry)
 
 
-@cli.command("status")
-@pass_context_object
-def status(context: ContextObject):
-    """displays currently tracked (if active)"""
-    time_entry = context.tts.get_active_entry()
-    context.output.single_entry_output(time_entry)
+@cappa.command(name="stop", help="stop tracking work on a project")
+@dataclass
+class Stop:
+    comment: str = ""
+    stop_time: Annotated[
+        datetime | None,
+        cappa.Arg(
+            short="-s",
+            long="--stop_time",
+            parse=validate_time,
+            parse_inference=False,
+            help="Stop/End time expressed as HH:MM or HH:MM:SS in 24-hour format or AM/PM",
+        ),
+    ] = None
+
+    def __call__(self, context: Context) -> None:
+        try:
+            if self.comment:
+                time_entry = context.tts.get_active_entry()
+                time_entry.comment = self.comment
+                time_entry = context.tts.update_entry(time_entry)
+            time_entry = context.tts.stop_tracking(stop_time=self.stop_time)
+        except ValueError as e:
+            raise cappa.Exit(str(e), code=1) from e
+        context.output.single_entry_output(time_entry)
 
 
-@cli.command("edit")
-@click.argument("id", required=True, type=str)
-@pass_context_object
-def edit_entry(context: ContextObject, id):
-    """edit a time entry using the system editor"""
-    try:
-        entry = context.tts.get_entry_by_partial_id(id)
-    except KeyError as e:
-        raise click.ClickException(f"No entry found with id {id}") from e
-    except IndexError as e:
-        raise click.ClickException(f"Multiple records found starting with id {id}") from e
-    try:
-        context.output.single_entry_output(context.tts.edit_entry(entry.id))
-    except EditorError as e:
-        raise click.ClickException(f"Error editing entry: {str(e)}") from e
+@cappa.command(name="status", help="displays currently tracked (if active)")
+@dataclass
+class Status:
+    def __call__(self, context: Context) -> None:
+        time_entry = context.tts.get_active_entry()
+        context.output.single_entry_output(time_entry)
 
 
-@cli.command("delete", aliases=["del", "rm"])
-@click.argument("id", required=True, type=str)
-@pass_context_object
-def delete_entry(context: ContextObject, id):
-    """delete a time entry"""
-    try:
-        entry = context.tts.get_entry_by_partial_id(id)  # Get the entry to delete
-    except KeyError as e:
-        raise click.ClickException(f"No entry found with id {id}") from e
-    except IndexError as e:
-        raise click.ClickException(f"Multiple records found starting with id {id}") from e
-    entry = context.tts.delete_entry(entry.id)
-    context.output.single_entry_output(entry)
+@cappa.command(name="edit", help="edit a time entry using the system editor")
+@dataclass
+class Edit:
+    id: str
+
+    def __call__(self, context: Context) -> None:
+        try:
+            entry = context.tts.get_entry_by_partial_id(self.id)
+        except KeyError as e:
+            raise cappa.Exit(f"No entry found with id {self.id}", code=1) from e
+        except IndexError as e:
+            raise cappa.Exit(f"Multiple records found starting with id {self.id}", code=1) from e
+        try:
+            context.output.single_entry_output(context.tts.edit_entry(entry.id))
+        except EditorError as e:
+            raise cappa.Exit(f"Error editing entry: {str(e)}", code=1) from e
 
 
-@cli.command("list", aliases=["ls"])
-@click.argument(
-    "time_period",
-    required=False,
-    type=click.Choice(["today", "yesterday", "week", "month", "all", ""]),
-    default="",
-)
-@click.option(
-    "--start_date",
-    type=click.DateTime(formats=["%Y-%m-%d"]),
-    help="Start date in format YYYY-MM-DD",
-)
-@click.option("--end_date", type=click.DateTime(formats=["%Y-%m-%d"]), help="End date in format YYYY-MM-DD")
-@click.option("--tag", multiple=True)
-@click.option("--project", multiple=True)
-@pass_context_object
-def list_entries(context: ContextObject, time_period, start_date, end_date, tag, project):
+@cappa.command(name="delete", aliases=["del", "rm"], help="delete a time entry")
+@dataclass
+class Delete:
+    id: str
+
+    def __call__(self, context: Context) -> None:
+        try:
+            entry = context.tts.get_entry_by_partial_id(self.id)
+        except KeyError as e:
+            raise cappa.Exit(f"No entry found with id {self.id}", code=1) from e
+        except IndexError as e:
+            raise cappa.Exit(f"Multiple records found starting with id {self.id}", code=1) from e
+        entry = context.tts.delete_entry(entry.id)
+        context.output.single_entry_output(entry)
+
+
+@cappa.command(name="list", aliases=["ls"], help="display list of time entries for a time period")
+@dataclass
+class List:
     """display list of time entries for a time period
 
     Default behavior (no time_period): shows today's entries, plus any active entry from a previous date.
     Use 'all' to display all time entries.
     """
-    filter = EntryListFilter(
-        time_period=time_period,
-        start_date=start_date,
-        end_date=end_date,
-        tags=set(tag),
-        projects=set(project),
-    )
-    time_list = context.tts.list_entries(filter=filter)
-    context.output.multiple_entries_output(time_list)
+
+    time_period: Annotated[str, cappa.Arg(choices=["today", "yesterday", "week", "month", "all", ""])] = ""
+    start_date: Annotated[
+        date | None,
+        cappa.Arg(
+            long="--start_date",
+            parse=_parse_date,
+            parse_inference=False,
+            help="Start date in format YYYY-MM-DD",
+        ),
+    ] = None
+    end_date: Annotated[
+        date | None,
+        cappa.Arg(
+            long="--end_date",
+            parse=_parse_date,
+            parse_inference=False,
+            help="End date in format YYYY-MM-DD",
+        ),
+    ] = None
+    tag: Annotated[list[str], cappa.Arg(long=True)] = field(default_factory=list)
+    project: Annotated[list[str], cappa.Arg(long=True)] = field(default_factory=list)
+
+    def __call__(self, context: Context) -> None:
+        filter = EntryListFilter(
+            time_period=self.time_period,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            tags=set(self.tag),
+            projects=set(self.project),
+        )
+        time_list = context.tts.list_entries(filter=filter)
+        context.output.multiple_entries_output(time_list)
 
 
-@cli.command("export")
-@click.argument("export_filename", required=True, type=click.Path(path_type=Path))
-@pass_context_object
-def export(context: ContextObject, export_filename):
-    """export time entries to a file"""
-    records_exported = context.tts.export_entries(export_filename)
-    context.output.export_output(records_exported, export_filename)
+@cappa.command(name="export", help="export time entries to a file")
+@dataclass
+class Export:
+    export_filename: Path
+
+    def __call__(self, context: Context) -> None:
+        records_exported = context.tts.export_entries(self.export_filename)
+        context.output.export_output(records_exported, self.export_filename)
+
+
+@cappa.command(name="sigye")
+@dataclass
+class Sigye:
+    """A simple command-line program for tracking time."""
+
+    config_file: Annotated[
+        Path,
+        cappa.Arg(short="-c", long="--config-file", help="Path to config file"),
+    ] = DEFAULT_CONFIG_PATH
+    filename: Annotated[
+        Path | None,
+        cappa.Arg(short="-f", long="--filename", help="Path to data file"),
+    ] = None
+    output_format: Annotated[
+        OutputType | None,
+        cappa.Arg(
+            short="-o",
+            long="--output_format",
+            parse=validate_output_format,
+            parse_inference=False,
+            help="Output format",
+        ),
+    ] = None
+    cmd: cappa.Subcommands[Start | Stop | Status | Edit | Delete | List | Export] = None
+
+
+def cli(argv: list[str] | None = None) -> None:
+    cappa.invoke(Sigye, argv=argv)

--- a/src/sigye/output/output_utils.py
+++ b/src/sigye/output/output_utils.py
@@ -1,15 +1,13 @@
-from typing import Any
-
-import click
+import cappa
 
 from .output import OutputType
 
 
-def validate_output_format(ctx: click.Context, param: Any, value: str | None) -> OutputType | None:
-    """Validation callback for the output format option."""
-    if value is not None:
-        try:
-            return OutputType(value.lower())
-        except ValueError as e:
-            raise click.BadParameter(f"Invalid output format: {value}") from e
-    return None
+def validate_output_format(value: str | None) -> OutputType | None:
+    """Parser for the output format option."""
+    if value is None or value == "":
+        return None
+    try:
+        return OutputType(value.lower())
+    except ValueError as e:
+        raise cappa.Exit(f"Invalid output format: {value}", code=2) from e

--- a/src/sigye/output/tests/test_utils.py
+++ b/src/sigye/output/tests/test_utils.py
@@ -1,14 +1,15 @@
-import click
+import cappa
 import pytest
 
+from ..output import OutputType
 from ..output_utils import validate_output_format
 
 
 def test_validate_output_format():
-    assert validate_output_format(None, None, "json") == "json"
-    with pytest.raises(click.BadParameter):
-        validate_output_format(None, None, "invalid")
-    assert validate_output_format(None, None, None) is None
-    assert validate_output_format(None, None, "YAML") == "yaml"
-    with pytest.raises(click.BadParameter):
-        validate_output_format(None, None, "INVALID")
+    assert validate_output_format("json") == OutputType.JSON
+    with pytest.raises(cappa.Exit):
+        validate_output_format("invalid")
+    assert validate_output_format(None) is None
+    assert validate_output_format("YAML") == OutputType.YAML
+    with pytest.raises(cappa.Exit):
+        validate_output_format("INVALID")

--- a/src/sigye/tests/test_cli.py
+++ b/src/sigye/tests/test_cli.py
@@ -1,9 +1,12 @@
+import io
+import os
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from dataclasses import dataclass
 from pathlib import Path
 from unittest import mock
 
-from click.testing import CliRunner
-
-from ..cli import cli, load_settings
+from ..cli import cli as cli_main
+from ..cli import load_settings
 from ..models import TimeEntry
 from ..output.text_output import RawTextOutput
 
@@ -12,12 +15,40 @@ def mock_single_entry_output(entry: TimeEntry):
     print(f"{entry.id} {entry.start_time} {entry.end_time} {entry.project} {entry.comment}")
 
 
+@dataclass
+class CliResult:
+    exit_code: int
+    output: str
+
+
+class CliRunner:
+    """Minimal click-CliRunner-style helper around cappa.invoke."""
+
+    @contextmanager
+    def isolated_filesystem(self, temp_dir: Path):
+        cwd = os.getcwd()
+        os.chdir(temp_dir)
+        try:
+            yield
+        finally:
+            os.chdir(cwd)
+
+    def invoke(self, argv: list[str]) -> CliResult:
+        buf = io.StringIO()
+        try:
+            with redirect_stdout(buf), redirect_stderr(buf):
+                cli_main(argv=list(argv))
+            exit_code = 0
+        except SystemExit as e:
+            exit_code = e.code if isinstance(e.code, int) else 1
+        return CliResult(exit_code, buf.getvalue())
+
+
 def test_load_settings(tmp_path):
     """Test settings loading with default and custom config"""
     settings = load_settings()
     assert settings is not None
 
-    # Test with custom config
     config_file = tmp_path / "config.yaml"
     config_content = """
     locale: en_US
@@ -33,14 +64,11 @@ def test_start_command(tmp_path):
     """Test the start command"""
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # Basic start command
-        result = runner.invoke(cli, ["-f", "test.yaml", "start", "test-project"])
+        result = runner.invoke(["-f", "test.yaml", "start", "test-project"])
         assert result.exit_code == 0
         assert "test-project" in result.output
 
-        # Start with comment and tags
         result = runner.invoke(
-            cli,
             [
                 "-f",
                 "test.yaml",
@@ -59,13 +87,11 @@ def test_start_command(tmp_path):
         assert "tag1" in result.output
         assert "tag2" in result.output
 
-        # Start with specific time
-        result = runner.invoke(cli, ["-f", "test2.yaml", "start", "test-project", "--start_time", "09:00"])
+        result = runner.invoke(["-f", "test2.yaml", "start", "test-project", "--start_time", "09:00"])
         assert result.exit_code == 0
         assert "09:00" in result.output
 
-        # Invalid time format
-        result = runner.invoke(cli, ["-f", "test3.yaml", "start", "test-project", "--start_time", "invalid"])
+        result = runner.invoke(["-f", "test3.yaml", "start", "test-project", "--start_time", "invalid"])
         assert result.exit_code != 0
         assert "Invalid time format" in result.output
 
@@ -74,23 +100,19 @@ def test_stop_command(tmp_path):
     """Test the stop command"""
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # Start tracking first
-        runner.invoke(cli, ["-f", "test.yaml", "start", "test-project"])
+        runner.invoke(["-f", "test.yaml", "start", "test-project"])
 
-        # Basic stop
-        result = runner.invoke(cli, ["-f", "test.yaml", "stop"])
+        result = runner.invoke(["-f", "test.yaml", "stop"])
         assert result.exit_code == 0
         assert "test-project" in result.output
 
-        # Stop with specific time
-        runner.invoke(cli, ["-f", "test2.yaml", "start", "test-project", "--start_time", "09:00"])
-        result = runner.invoke(cli, ["-f", "test2.yaml", "stop", "--stop_time", "17:00"])
+        runner.invoke(["-f", "test2.yaml", "start", "test-project", "--start_time", "09:00"])
+        result = runner.invoke(["-f", "test2.yaml", "stop", "--stop_time", "17:00"])
         assert result.exit_code == 0
         assert "17:00" in result.output
 
-        # Invalid time format
-        runner.invoke(cli, ["-f", "test3.yaml", "start", "test-project", "--start_time", "09:00"])
-        result = runner.invoke(cli, ["-f", "test3.yaml", "stop", "--stop_time", "invalid"])
+        runner.invoke(["-f", "test3.yaml", "start", "test-project", "--start_time", "09:00"])
+        result = runner.invoke(["-f", "test3.yaml", "stop", "--stop_time", "invalid"])
         assert result.exit_code != 0
         assert "Invalid time format" in result.output
 
@@ -99,14 +121,12 @@ def test_status_command(tmp_path):
     """Test the status command"""
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # Check status with no active tracking
-        result = runner.invoke(cli, ["-f", "test.yaml", "status"])
+        result = runner.invoke(["-f", "test.yaml", "status"])
         assert result.exit_code == 0
         assert "No active time record" in result.output
 
-        # Start tracking and check status
-        runner.invoke(cli, ["-f", "test.yaml", "start", "test-project", "test comment"])
-        result = runner.invoke(cli, ["-f", "test.yaml", "status"])
+        runner.invoke(["-f", "test.yaml", "start", "test-project", "test comment"])
+        result = runner.invoke(["-f", "test.yaml", "status"])
         assert result.exit_code == 0
         assert "test-project" in result.output
         assert "test comment" in result.output
@@ -116,38 +136,32 @@ def test_list_command_and_aliases(tmp_path):
     """Test the list command and its aliases"""
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # Create some entries
-        runner.invoke(cli, ["-f", "test.yaml", "start", "project1", "--tag", "tag1"])
-        runner.invoke(cli, ["-f", "test.yaml", "stop"])
-        runner.invoke(cli, ["-f", "test.yaml", "start", "project2", "--tag", "tag2"])
-        runner.invoke(cli, ["-f", "test.yaml", "stop"])
+        runner.invoke(["-f", "test.yaml", "start", "project1", "--tag", "tag1"])
+        runner.invoke(["-f", "test.yaml", "stop"])
+        runner.invoke(["-f", "test.yaml", "start", "project2", "--tag", "tag2"])
+        runner.invoke(["-f", "test.yaml", "stop"])
 
-        # Test main 'list' command
-        result = runner.invoke(cli, ["-f", "test.yaml", "list"])
+        result = runner.invoke(["-f", "test.yaml", "list"])
         assert result.exit_code == 0
         assert "project1" in result.output
         assert "project2" in result.output
 
-        # Test 'ls' alias
-        result = runner.invoke(cli, ["-f", "test.yaml", "ls"])
+        result = runner.invoke(["-f", "test.yaml", "ls"])
         assert result.exit_code == 0
         assert "project1" in result.output
         assert "project2" in result.output
 
-        # List with time period
-        result = runner.invoke(cli, ["-f", "test.yaml", "list", "today"])
+        result = runner.invoke(["-f", "test.yaml", "list", "today"])
         assert result.exit_code == 0
         assert "project1" in result.output
         assert "project2" in result.output
 
-        # List with project filter
-        result = runner.invoke(cli, ["-f", "test.yaml", "list", "--project", "project1"])
+        result = runner.invoke(["-f", "test.yaml", "list", "--project", "project1"])
         assert result.exit_code == 0
         assert "project1" in result.output
         assert "project2" not in result.output
 
-        # List with tag filter
-        result = runner.invoke(cli, ["-f", "test.yaml", "list", "--tag", "tag1"])
+        result = runner.invoke(["-f", "test.yaml", "list", "--tag", "tag1"])
         assert result.exit_code == 0
         assert "project1" in result.output
         assert "project2" not in result.output
@@ -160,16 +174,13 @@ def test_edit_command(tmp_path):
         mock.patch("sigye.output.rich_text_output.RichTextOutput", side_effect=RawTextOutput),
         runner.isolated_filesystem(temp_dir=tmp_path),
     ):
-        # Create an entry
-        result = runner.invoke(cli, ["-f", "test.yaml", "start", "test-project"])
-        runner.invoke(cli, ["-f", "test.yaml", "stop"])
+        result = runner.invoke(["-f", "test.yaml", "start", "test-project"])
+        runner.invoke(["-f", "test.yaml", "stop"])
 
-        # Extract the ID from the output
-        entry_id = result.output.split()[0]  # Assuming ID is first word in output
+        entry_id = result.output.split()[0]
         assert entry_id is not None
 
-        # Try to edit with invalid ID
-        result = runner.invoke(cli, ["-f", "test.yaml", "edit", "invalid-id"])
+        result = runner.invoke(["-f", "test.yaml", "edit", "invalid-id"])
         assert result.exit_code != 0
         assert "No entry found" in result.output
 
@@ -178,40 +189,31 @@ def test_delete_command_and_aliases(tmp_path):
     """Test the delete command and its aliases"""
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # Create an entry
-        result = runner.invoke(cli, ["-f", "test.yaml", "-o", "text", "start", "test-project"])
-        runner.invoke(cli, ["-f", "test.yaml", "-o", "text", "stop"])
-        print(f"output: {result.output}")
-        # Extract the ID from the output
-        entry_id = result.output.split()[0]  # Assuming ID is first word in output
-
-        # Test main 'delete' command
-        result = runner.invoke(cli, ["-f", "test.yaml", "-o", "text", "delete", entry_id])
-        assert result.exit_code == 0
-        assert "test-project" in result.output
-
-        # Create another entry for testing aliases
-        result = runner.invoke(cli, ["-f", "test.yaml", "-o", "text", "start", "test-project"])
-        runner.invoke(cli, ["-f", "test.yaml", "stop"])
+        result = runner.invoke(["-f", "test.yaml", "-o", "text", "start", "test-project"])
+        runner.invoke(["-f", "test.yaml", "-o", "text", "stop"])
         entry_id = result.output.split()[0]
 
-        # Test 'rm' alias
-        result = runner.invoke(cli, ["-f", "test.yaml", "-o", "text", "rm", entry_id])
+        result = runner.invoke(["-f", "test.yaml", "-o", "text", "delete", entry_id])
         assert result.exit_code == 0
         assert "test-project" in result.output
 
-        # Create another entry for testing aliases
-        result = runner.invoke(cli, ["-f", "test.yaml", "-o", "text", "start", "test-project"])
-        runner.invoke(cli, ["-f", "test.yaml", "stop"])
+        result = runner.invoke(["-f", "test.yaml", "-o", "text", "start", "test-project"])
+        runner.invoke(["-f", "test.yaml", "stop"])
         entry_id = result.output.split()[0]
 
-        # Test 'del' alias
-        result = runner.invoke(cli, ["-f", "test.yaml", "-o", "text", "del", entry_id])
+        result = runner.invoke(["-f", "test.yaml", "-o", "text", "rm", entry_id])
         assert result.exit_code == 0
         assert "test-project" in result.output
 
-        # Try to delete with invalid ID
-        result = runner.invoke(cli, ["-f", "test.yaml", "-o", "text", "delete", "invalid-id"])
+        result = runner.invoke(["-f", "test.yaml", "-o", "text", "start", "test-project"])
+        runner.invoke(["-f", "test.yaml", "stop"])
+        entry_id = result.output.split()[0]
+
+        result = runner.invoke(["-f", "test.yaml", "-o", "text", "del", entry_id])
+        assert result.exit_code == 0
+        assert "test-project" in result.output
+
+        result = runner.invoke(["-f", "test.yaml", "-o", "text", "delete", "invalid-id"])
         assert result.exit_code != 0
         assert "No entry found" in result.output
 
@@ -220,7 +222,6 @@ def test_config_file_option(tmp_path):
     """Test using custom config file"""
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # Create custom config
         config_file = tmp_path / "custom_config.yaml"
         config_content = """
         locale: en_US
@@ -228,7 +229,6 @@ def test_config_file_option(tmp_path):
         """
         config_file.write_text(config_content)
 
-        # Use custom config
-        result = runner.invoke(cli, ["-c", str(config_file), "start", "test-project"])
+        result = runner.invoke(["-c", str(config_file), "start", "test-project"])
         assert result.exit_code == 0
         assert "test-project" in result.output

--- a/src/sigye/utils/datetime_utils.py
+++ b/src/sigye/utils/datetime_utils.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime, time, timedelta
 
-import click
+import cappa
 import humanize
 
 
@@ -57,13 +57,13 @@ def adjust_stop_time(start_time: datetime, stop_time: datetime) -> datetime:
     return stop_time
 
 
-def validate_time(ctx: click.Context, param: click.Parameter, value: str | None) -> datetime | None:
+def validate_time(value: str | None) -> datetime | None:
     if value is None:
         return None
     try:
         return parse_time(value)
     except ValueError as ex:
-        raise click.BadParameter(str(ex)) from ex
+        raise cappa.Exit(str(ex), code=2) from ex
 
 
 def format_delta(td: timedelta) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -17,8 +17,8 @@ wheels = [
 
 [[package]]
 name = "cappa"
-version = "0.31.1"
-source = { git = "https://github.com/swilcox/cappa.git?rev=feat%2Faliased-subcommands#0ba3eb2ed0188b72896234fcfe03c5116b18741c" }
+version = "0.32.0"
+source = { git = "https://github.com/DanCardin/cappa.git?branch=main#07154bbb8b48b4e6822c98619549b335428b4d83" }
 dependencies = [
     { name = "rich" },
     { name = "type-lens" },
@@ -574,7 +574,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cappa", git = "https://github.com/swilcox/cappa.git?rev=feat%2Faliased-subcommands" },
+    { name = "cappa", git = "https://github.com/DanCardin/cappa.git?branch=main" },
     { name = "humanize", specifier = ">=4.11.0" },
     { name = "jinja2", specifier = ">=3.1.5" },
     { name = "peewee", specifier = ">=3.17.8" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -12,27 +16,13 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.3.1"
-source = { registry = "https://pypi.org/simple" }
+name = "cappa"
+version = "0.31.1"
+source = { git = "https://github.com/swilcox/cappa.git?rev=feat%2Faliased-subcommands#0ba3eb2ed0188b72896234fcfe03c5116b18741c" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
-]
-
-[[package]]
-name = "click-aliases"
-version = "1.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/d8/adbaeadc13c9686b9bda8b4c50e5a3983f504faae2ffbea5165d5beb1cdb/click_aliases-1.0.5.tar.gz", hash = "sha256:e37d4cabbaad68e1c48ec0f063a59dfa15f0e7450ec901bd1ce4f4b954bc881d", size = 3105, upload-time = "2024-10-17T15:44:19.056Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/1a/d5e29a6f896293e32ab3e63201df5d396599e57a726575adaafbcd9d70a6/click_aliases-1.0.5-py3-none-any.whl", hash = "sha256:cbb83a348acc00809fe18b6da13a7f6307bc71b3c5f69cc730e012dfb4bbfdc3", size = 3524, upload-time = "2024-10-17T15:44:17.389Z" },
+    { name = "rich" },
+    { name = "type-lens" },
+    { name = "typing-extensions" },
 ]
 
 [[package]]
@@ -563,8 +553,7 @@ name = "sigye"
 version = "0.10.2"
 source = { editable = "." }
 dependencies = [
-    { name = "click" },
-    { name = "click-aliases" },
+    { name = "cappa" },
     { name = "humanize" },
     { name = "jinja2" },
     { name = "peewee" },
@@ -585,8 +574,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.1.7" },
-    { name = "click-aliases", specifier = ">=1.0.5" },
+    { name = "cappa", git = "https://github.com/swilcox/cappa.git?rev=feat%2Faliased-subcommands" },
     { name = "humanize", specifier = ">=4.11.0" },
     { name = "jinja2", specifier = ">=3.1.5" },
     { name = "peewee", specifier = ">=3.17.8" },
@@ -612,6 +600,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "type-lens"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/55/8846322acedf26cafb4a66dd23fdca6bc73cb3f8c0029040a9b96f5aa0dd/type_lens-0.2.6.tar.gz", hash = "sha256:5d46ab3bc2dfafc174cad702eccb4418c31e38e258e87945a19d86ebc204d08b", size = 362277, upload-time = "2025-10-20T20:08:28.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/c5/30de077e06f7ffc3fe21d45ce26b8088816227b678a7157f6b9e080ff2db/type_lens-0.2.6-py3-none-any.whl", hash = "sha256:aade6beb3eca337c90d1b627b509768473bbd591e233ed6b57fb93ec2a01bca6", size = 14451, upload-time = "2025-10-20T20:08:26.936Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace `click` / `click-aliases` with [`cappa`](https://github.com/DanCardin/cappa) for the command-line interface
- Update `cli.py` to use cappa's command definitions
- Adjust output and datetime utilities and their tests for the new CLI

## Notes
- `cappa` tracks the upstream `DanCardin/cappa` **main** branch (currently v0.32.0) via `[tool.uv.sources]`, which now includes the merged aliased-subcommand support. The lock pins a specific commit for reproducibility; switch to a released version once one is published.

## Test plan
- [x] `uv run pytest` (68 passed)