### PR TITLE
Infer prior-day date when stopping a stale active entry

### DIFF
--- a/src/sigye/services.py
+++ b/src/sigye/services.py
@@ -5,6 +5,7 @@ from .editors import Editor
 from .editors.shell_editor import ShellEditor
 from .models import EntryListFilter, TimeEntry
 from .repositories import TimeEntryRepository, TimeEntryRepositoryFile, TimeEntryRepositoryORM
+from .utils.datetime_utils import adjust_stop_time
 
 
 class TimeTrackingService:
@@ -52,6 +53,8 @@ class TimeTrackingService:
         """Stop the active time entry"""
         active_entry = self.repository.get_active_entry()
         if active_entry:
+            if stop_time is not None:
+                stop_time = adjust_stop_time(active_entry.start_time, stop_time)
             active_entry.stop(stop_time)
             self.repository.save(active_entry)
             return active_entry

--- a/src/sigye/tests/test_services.py
+++ b/src/sigye/tests/test_services.py
@@ -113,6 +113,44 @@ def test_start_stop(tmp_path):
     assert d1.end_time is not None
 
 
+def test_stop_tracking_infers_prior_day_for_stale_active_entry(tmp_path):
+    """Stopping an entry left running from a prior day with a bare time-of-day
+    should land on the entry's start date, not today."""
+    filename = tmp_path / "test.yaml"
+    settings = create_test_settings(tmp_path)
+    tts = TimeTrackingService(repository=TimeEntryRepositoryFile(filename), settings=settings)
+
+    now = datetime.now().astimezone()
+    start = (now - timedelta(days=1)).replace(hour=9, minute=0, second=0, microsecond=0)
+
+    entry = tts.start_tracking("stale-project", start_time=start)
+    assert entry.end_time is None
+
+    # Simulate `sigye stop -s 17:00`: parse_time stamps 17:00 onto today.
+    requested_stop = now.replace(hour=17, minute=0, second=0, microsecond=0)
+    stopped = tts.stop_tracking(stop_time=requested_stop)
+
+    assert stopped.end_time.date() == start.date()
+    assert stopped.end_time.hour == 17
+    assert stopped.duration == timedelta(hours=8)
+
+
+def test_stop_tracking_keeps_today_for_active_entry_from_today(tmp_path):
+    """Stopping a same-day entry must not have its date reinterpreted."""
+    filename = tmp_path / "test.yaml"
+    settings = create_test_settings(tmp_path)
+    tts = TimeTrackingService(repository=TimeEntryRepositoryFile(filename), settings=settings)
+
+    now = datetime.now().astimezone()
+    start = now.replace(hour=9, minute=0, second=0, microsecond=0)
+
+    tts.start_tracking("today-project", start_time=start)
+    requested_stop = now.replace(hour=17, minute=0, second=0, microsecond=0)
+    stopped = tts.stop_tracking(stop_time=requested_stop)
+
+    assert stopped.end_time == requested_stop
+
+
 def test_filtered_list(tmp_path):
     filename = tmp_path / "test.yaml"
     settings = create_test_settings(tmp_path)

--- a/src/sigye/utils/datetime_utils.py
+++ b/src/sigye/utils/datetime_utils.py
@@ -41,6 +41,22 @@ def parse_time(time_str: str) -> datetime:
     return datetime.combine(today, time(hours, minutes, seconds)).astimezone()
 
 
+def adjust_stop_time(start_time: datetime, stop_time: datetime) -> datetime:
+    """Reinterpret a bare time-of-day stop time against the active entry's start date.
+
+    A stop time entered as just a time of day (e.g. ``17:00``) is parsed against
+    today's date. When the active entry was actually started on an earlier day -- the
+    common "forgot to run ``sigye stop`` before leaving" case -- assume the user meant
+    that time on the entry's start date instead of today, as long as it still falls
+    after the start time. Otherwise the original stop time is returned unchanged.
+    """
+    if start_time.date() < stop_time.date():
+        candidate = datetime.combine(start_time.date(), stop_time.timetz())
+        if candidate > start_time:
+            return candidate
+    return stop_time
+
+
 def validate_time(ctx: click.Context, param: click.Parameter, value: str | None) -> datetime | None:
     if value is None:
         return None

--- a/src/sigye/utils/tests/test_datetime.py
+++ b/src/sigye/utils/tests/test_datetime.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from freezegun import freeze_time
 
-from ..datetime_utils import format_delta, parse_time
+from ..datetime_utils import adjust_stop_time, format_delta, parse_time
 
 
 @freeze_time("2021-01-01")
@@ -45,6 +45,36 @@ def test_parse_time():
         parse_time("13:00:00 AM")
     with pytest.raises(ValueError):
         parse_time("13:00:00 PM")
+
+
+def test_adjust_stop_time_prior_day():
+    # Active entry started yesterday morning; a bare "17:00" parsed as today
+    # should be pulled back to the entry's start date.
+    start = datetime(2021, 1, 1, 9, 0).astimezone()
+    today_stop = datetime(2021, 1, 2, 17, 0).astimezone()
+    assert adjust_stop_time(start, today_stop) == datetime(2021, 1, 1, 17, 0).astimezone()
+
+
+def test_adjust_stop_time_multiple_days_prior():
+    # The start date is used even when the entry is several days stale.
+    start = datetime(2021, 1, 1, 9, 0).astimezone()
+    today_stop = datetime(2021, 1, 4, 17, 0).astimezone()
+    assert adjust_stop_time(start, today_stop) == datetime(2021, 1, 1, 17, 0).astimezone()
+
+
+def test_adjust_stop_time_same_day_unchanged():
+    # When the entry started today, the stop time is left untouched.
+    start = datetime(2021, 1, 2, 9, 0).astimezone()
+    stop = datetime(2021, 1, 2, 17, 0).astimezone()
+    assert adjust_stop_time(start, stop) == stop
+
+
+def test_adjust_stop_time_before_start_falls_back():
+    # If the stop time-of-day is before the start time-of-day, pulling it back to
+    # the start date would be invalid, so the original (today) value is kept.
+    start = datetime(2021, 1, 1, 18, 0).astimezone()
+    today_stop = datetime(2021, 1, 2, 17, 0).astimezone()
+    assert adjust_stop_time(start, today_stop) == today_stop
 
 
 def test_format_timedelta():


### PR DESCRIPTION
## Problem
A bare time-of-day passed to `sigye stop -s` (e.g. `sigye stop -s 17:00`) is parsed against **today's** date by `parse_time`. If you forget to run `sigye stop` before leaving for the day, the next morning the active entry gets stopped at *today* 17:00 — producing a 24h+ duration.

## Fix
New pure helper `adjust_stop_time(start_time, stop_time)` in `datetime_utils.py`, called from `TimeTrackingService.stop_tracking`:

- When the active entry was started on an **earlier day**, reinterpret the bare stop time against the entry's **start date**.
- Only applies when the result still falls **after** the start time (so it never creates an invalid `end < start`); otherwise the stop time is left unchanged.
- Same-day entries are never touched.

### Examples
- Started yesterday 09:00, `sigye stop -s 17:00` → stops at **yesterday 17:00** (8h) instead of today 17:00.
- Started 3 days ago 09:00, `sigye stop -s 17:00` → stops on that **start date** at 17:00.
- Started yesterday 18:00, `sigye stop -s 17:00` (before start time-of-day) → falls back to **today 17:00** (unchanged).

## Tests
- `test_datetime.py`: 4 unit tests for `adjust_stop_time` (prior day, multi-day-stale, same-day-unchanged, before-start fallback).
- `test_services.py`: 2 tests covering the full `stop_tracking` flow for stale vs. same-day active entries.

Full suite: 68 passed; ruff clean.